### PR TITLE
Pull JDownloader, 7zipjbinding, and JRE from official sources + Firefox captcha solving + multi-flavor build pipeline

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,89 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      IMAGE_NAME: null
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # 1) Legacy implementation using ich777 tarball -> :legacy and :latest
+          - name: legacy
+            image_tag: legacy
+            build_context: .
+            dockerfile: ./Dockerfile
+
+          # 2) Download resources from official sources (Temurin + official JD & sevenzip) -> :download_official
+          - name: download_official
+            image_tag: download_official
+            build_context: .
+            dockerfile: ./Dockerfile.download_official
+
+          # 3) Official download + Firefox/Fluxbox desktop flavor -> :firefox
+          - name: firefox
+            image_tag: firefox
+            build_context: .
+            dockerfile: ./Dockerfile.download_official
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Inspect base images' manifests
+        run: |
+          # Print available platforms for upstream base images to the workflow log
+          docker buildx imagetools inspect ich777/novnc-baseimage || docker manifest inspect ich777/novnc-baseimage || true
+          docker buildx imagetools inspect ich777/debian-baseimage || docker manifest inspect ich777/debian-baseimage || true
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute lowercase image name
+        run: echo "IMAGE_NAME=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Build and push ${{ matrix.name }} image
+        uses: docker/build-push-action@v4
+        with:
+          context: ${{ matrix.build_context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          # ich777's novnc-baseimage pulls an amd64 TurboVNC .deb — restrict to amd64
+          platforms: linux/amd64
+          build-args: |
+            FLAVOR=${{ matrix.image_tag }}
+          tags: |
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.image_tag }}
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.image_tag }}-${{ github.sha }}
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.image_tag }}-${{ github.ref_name }}
+
+      - name: Tag legacy as latest on GHCR
+        if: matrix.name == 'legacy'
+        run: |
+          ref="ghcr.io/${IMAGE_NAME}"
+          docker buildx imagetools create \
+            --tag "${ref}:latest" \
+            "${ref}:legacy"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 FROM ich777/novnc-baseimage
 
+# Legacy flavor image
+#
+# Built and published as:
+#   - ghcr.io/<owner>/docker-jdownloader2:legacy
+#   - ghcr.io/<owner>/docker-jdownloader2:latest
+#
+# Uses the legacy runtime layout and start logic via
+#   IMAGE_FLAVOR=legacy -> scripts/start-server.sh -> start-server-legacy.sh
+
 LABEL org.opencontainers.image.authors="admin@minenet.at"
 LABEL org.opencontainers.image.source="https://github.com/ich777/docker-jdownloader2"
 

--- a/Dockerfile.download_official
+++ b/Dockerfile.download_official
@@ -1,0 +1,233 @@
+FROM ich777/novnc-baseimage
+
+# Official-download flavors image
+#
+# Built and published as:
+#   - ghcr.io/<owner>/docker-jdownloader2:download_official  (FLAVOR=download_official)
+#   - ghcr.io/<owner>/docker-jdownloader2:firefox            (FLAVOR=firefox)
+#
+# IMAGE_FLAVOR is set from FLAVOR and used by scripts/start-server.sh
+# to select the appropriate start-server implementation and Fluxbox config.
+
+LABEL org.opencontainers.image.authors="admin@minenet.at"
+LABEL org.opencontainers.image.source="https://github.com/ich777/docker-jdownloader2"
+
+# Build‑time args/env (changing requires rebuild)
+ARG FLAVOR=download_official
+ENV IMAGE_FLAVOR=${FLAVOR}
+ARG JD_DOWNLOAD_URL="https://installer.jdownloader.org/JDownloader.jar"
+ARG JD_SHA_PAGE_URL="https://support.jdownloader.org/de/knowledgebase/article/install-jdownloader-on-nas-and-embedded-devices"
+ARG JD_SHA256=""
+ARG SEVENZIP_BEST_URL="https://sourceforge.net/projects/sevenzipjbind/best_release.json"
+ARG SEVENZIP_FALLBACK_URL="https://sourceforge.net/projects/sevenzipjbind/files/7-Zip-JBinding/16.02-2.01/sevenzipjbinding-16.02-2.01-Linux-amd64.zip/download?use_mirror=master"
+ARG SEVENZIP_MD5=""
+ARG FIREFOX_EXT_URL="https://extensions.jdownloader.org/firefox.xpi"
+
+# Runtime env (internal, normally not exposed)
+ENV DATA_DIR=/jDownloader2
+ENV DOWNLOAD_DIR=/mnt/user/data/jdownloader
+ENV NOVNC_PORT=8080
+ENV RFB_PORT=5900
+ENV TURBOVNC_PARAMS="-securitytypes none"
+ENV RUNTIME_NAME="basicjre"
+ENV USER="jdownloader"
+ENV CONNECTED_CONTAINERS_TIMEOUT=60
+ENV DATA_PERM=770
+
+# Runtime env to expose in Unraid template
+ENV CUSTOM_RES_W=1280
+ENV CUSTOM_RES_H=1024
+ENV CUSTOM_DEPTH=16
+ENV UMASK=000
+ENV CONNECTED_CONTAINERS=""
+ENV UID=99
+ENV GID=100
+ENV SKIP_SHA_CHECKS=false
+ENV JAVA_RUNTIME_VERSION="jdk-24.0.2+12"
+ENV GITHUB_TOKEN=""
+
+
+RUN set -eux; \
+    apt-get update && apt-get upgrade -y && \
+    # always create data dir + user
+    mkdir $DATA_DIR && \
+	useradd -d $DATA_DIR -s /bin/bash $USER && \
+	chown -R $USER $DATA_DIR && \
+	ulimit -n 2048 && \
+	# only install Firefox for the firefox flavor
+	if [ "${IMAGE_FLAVOR}" = "firefox" ]; then \
+		apt-get -y install --no-install-recommends firefox-esr; \
+		mkdir -p ${DATA_DIR}/firefox-home && \
+		mkdir -p /usr/lib/firefox-esr/distribution/extensions && \
+		wget -O /usr/lib/firefox-esr/distribution/extensions/jid1-OY8Xu5BsKZQa6A@jetpack.xpi "${FIREFOX_EXT_URL}"; \
+	fi && \
+	# set timezone, install common packages and locales, set novnc title, clean up
+	export TZ=Europe/Rome && \
+	ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+	echo $TZ > /etc/timezone && \
+	apt-get -y install --no-install-recommends fonts-takao netcat-traditional wget curl jq nano xterm && \
+	apt-get -y install ffmpeg unzip && \
+	echo "ko_KR.UTF-8 UTF-8" >> /etc/locale.gen && \
+	echo "ja_JP.UTF-8 UTF-8" >> /etc/locale.gen && \
+	locale-gen && \
+	rm -rf /var/lib/apt/lists/* && \
+	sed -i '/    document.title =/c\    document.title = "jDownloader2 - noVNC";' /usr/share/novnc/app/ui.js && \
+	rm /usr/share/novnc/app/images/icons/*
+
+# Add start scripts and icons
+ADD /scripts/ /opt/scripts/
+COPY /icons/* /usr/share/novnc/app/images/icons/
+
+# Download and verify JDownloader.jar
+RUN set -eux; \
+	skip_flag="$(printf '%s' "${SKIP_SHA_CHECKS}" | tr '[:upper:]' '[:lower:]')"; \
+	jd_expected="${JD_SHA256}"; \
+	jd_support_tmp="/tmp/jd_support.html"; \
+	jd_jar="/tmp/JDownloader.jar"; \
+	if [ "$skip_flag" != "true" ]; then \
+		if [ -z "$jd_expected" ]; then \
+			echo "JD_SHA256 empty; attempting to scrape ${JD_SHA_PAGE_URL}"; \
+			if curl -fsSL "${JD_SHA_PAGE_URL}" -o "$jd_support_tmp"; then \
+				extract_sha() { \
+					_file="$1"; \
+					line="$(grep -i 'sha256' "$_file" | head -n1 || true)"; \
+					if [ -n "$line" ]; then \
+						sha="$(echo "$line" | sed -nE 's/.*([A-Fa-f0-9]{64}).*/\1/p' | tr '[:upper:]' '[:lower:]' | head -n1 || true)"; \
+						[ -n "$sha" ] && { printf '%s' "$sha"; return 0; }; \
+					fi; \
+					hex="$(grep -ioE '[a-f0-9]{64}' "$_file" | head -n1 || true)"; \
+					[ -n "$hex" ] && { printf '%s' "$(echo "$hex" | tr '[:upper:]' '[:lower:]')"; return 0; }; \
+					return 1; \
+				}; \
+				jd_scraped="$(extract_sha "$jd_support_tmp" || true)"; \
+				if [ -n "$jd_scraped" ]; then \
+					jd_expected="$jd_scraped"; \
+					echo "Scraped JD_SHA256=$jd_expected"; \
+				else \
+					echo "Failed to scrape JD checksum"; \
+				fi; \
+			else \
+				echo "Could not download JD SHA page"; \
+			fi; \
+		else \
+			echo "JD_SHA256 provided via environment"; \
+		fi; \
+		if [ -z "$jd_expected" ]; then \
+			echo "Checksum enforcement enabled but no JD_SHA256 available"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "SKIP_SHA_CHECKS=true -> not verifying JDownloader.jar"; \
+	fi; \
+	echo "Downloading JDownloader.jar from ${JD_DOWNLOAD_URL}"; \
+	wget -O "$jd_jar" "${JD_DOWNLOAD_URL}"; \
+	ls -l "$jd_jar"; \
+	if [ "$skip_flag" != "true" ]; then \
+		calc="$(sha256sum "$jd_jar" | awk '{print $1}' || true)"; \
+		if [ -z "$calc" ]; then \
+			echo "Failed to compute SHA256 for JDownloader.jar"; \
+			exit 1; \
+		fi; \
+		normal_calc="$(printf '%s' "$calc" | tr '[:upper:]' '[:lower:]')"; \
+		normal_expected="$(printf '%s' "$jd_expected" | tr '[:upper:]' '[:lower:]')"; \
+		if [ "$normal_calc" != "$normal_expected" ]; then \
+			echo "SHA256 mismatch for JDownloader.jar (expected $normal_expected got $normal_calc)"; \
+			exit 1; \
+		fi; \
+		echo "JDownloader.jar checksum verified"; \
+	fi
+
+# Download and verify sevenzipjbinding
+RUN set -eux; \
+	skip_flag="$(printf '%s' "${SKIP_SHA_CHECKS}" | tr '[:upper:]' '[:lower:]')"; \
+	info_json="/tmp/seven_best.json"; \
+	filename=""; \
+	url=""; \
+	expected_md5="${SEVENZIP_MD5}"; \
+	saved_path=""; \
+	if curl -fsSL -H "Accept: application/json" "${SEVENZIP_BEST_URL}" -o "$info_json"; then \
+		if command -v jq >/dev/null 2>&1; then \
+			platform="linux"; \
+			filename_raw="$(jq -r --arg p "$platform" '.platform_releases[$p].filename // .release.filename // empty' "$info_json")"; \
+			url="$(jq -r --arg p "$platform" '.platform_releases[$p].url // .release.url // empty' "$info_json")"; \
+			if [ -z "$expected_md5" ] || [ "$expected_md5" = "null" ]; then \
+				expected_md5="$(jq -r --arg p "$platform" '.platform_releases[$p].md5sum // .release.md5sum // empty' "$info_json")"; \
+			fi; \
+			if [ -n "$filename_raw" ] && [ "$filename_raw" != "null" ]; then \
+				filename="$(basename "$filename_raw")"; \
+			fi; \
+		else \
+			echo "jq missing; skipping best_release parsing"; \
+		fi; \
+	else \
+		echo "Failed to fetch sevenzip best_release.json"; \
+	fi; \
+	if [ -z "$filename" ] || [ "$filename" = "null" ]; then \
+		filename="$(basename "${SEVENZIP_FALLBACK_URL}")"; \
+	fi; \
+	if [ -z "$url" ] || [ "$url" = "null" ]; then \
+		url="${SEVENZIP_FALLBACK_URL}"; \
+	fi; \
+	saved_path="/tmp/${filename}"; \
+	mkdir -p "$(dirname "$saved_path")"; \
+	echo "Downloading ${filename} from ${url}"; \
+	wget -O "$saved_path" "$url"; \
+	if [ "$skip_flag" != "true" ]; then \
+		if [ -z "$expected_md5" ] || [ "$expected_md5" = "null" ]; then \
+			echo "Checksum enforcement enabled but no MD5 available for sevenzip"; \
+			exit 1; \
+		fi; \
+		actual_md5="$(md5sum "$saved_path" | awk '{print $1}' || true)"; \
+		if [ -z "$actual_md5" ]; then \
+			echo "Failed to compute MD5 for ${filename}"; \
+			exit 1; \
+		fi; \
+		normal_md5="$(printf '%s' "$actual_md5" | tr '[:upper:]' '[:lower:]')"; \
+		expected_md5="$(printf '%s' "$expected_md5" | tr '[:upper:]' '[:lower:]')"; \
+		if [ "$normal_md5" != "$expected_md5" ]; then \
+			echo "MD5 mismatch for ${filename} (expected $expected_md5 got $normal_md5)"; \
+			exit 1; \
+		fi; \
+		echo "sevenzip MD5 verified"; \
+	else \
+		echo "SKIP_SHA_CHECKS=true -> not verifying sevenzip"; \
+	fi; \
+	workdir="/tmp/sevenzipjbinding"; \
+    rm -rf "$workdir"; \
+    mkdir -p "$workdir"; \
+    unzip -q "$saved_path" -d "$workdir" || (echo "unzip failed" && ls -R "$workdir" && false); \
+    rm -f "$saved_path"; \
+    libdir="$(find "$workdir" -type d -name lib | head -n1 || true)"; \
+    if [ -z "$libdir" ]; then \
+        echo "lib directory not found under $workdir"; \
+        ls -R "$workdir"; \
+        exit 1; \
+    fi; \
+    mv "$libdir" /tmp/lib; \
+    rm -rf "$workdir"; \
+	find /tmp -maxdepth 1 -mindepth 1 \
+		! -name 'lib' \
+		! -name 'JDownloader.jar' \
+		-exec rm -rf {} + || true
+
+# Copy fluxbox configuration based on flavor and provide JDownloader default configs
+COPY conf/ /tmp/conf_default/
+COPY conf_firefox/ /tmp/conf_firefox/
+COPY config/ /opt/jdownloader-defaults/
+RUN set -eux; \
+	if [ "${IMAGE_FLAVOR}" = "firefox" ]; then \
+		rm -rf /etc/.fluxbox && mv /tmp/conf_firefox /etc/.fluxbox; \
+	else \
+		rm -rf /etc/.fluxbox && mv /tmp/conf_default /etc/.fluxbox; \
+	fi; \
+	rm -rf /tmp/conf_default /tmp/conf_firefox
+
+# Final permissions
+RUN chmod -R 770 /opt/scripts/ && \
+	chown -R ${UID}:${GID} /mnt && \
+	chmod -R 770 /mnt
+
+EXPOSE 8080
+
+# Server Start
+ENTRYPOINT ["/opt/scripts/start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,99 +1,180 @@
 # jDownloader2 in Docker optimized for Unraid
+
 This Docker will download and install jDownloader2.
 
-JDownloader 2 is a free, open-source download management tool with a huge community of developers that makes downloading as easy and fast as it should be. Users can start, stop or pause downloads, set bandwith limitations, auto-extract archives and much more...
+JDownloader 2 is a free, open-source download management tool with a huge community of developers that makes downloading as easy and fast as it should be. Users can start, stop or pause downloads, set bandwidth limitations, auto-extract archives and much more...
 
+> [!TIP]
+> Please also check out the homepage from jDownloader: <http://jdownloader.org/>
 
->**Update Notice:** Updates will be handled through jDownloader2 directly, simply click the 'Check for Updates' in the WebGUI.
+> [!NOTE]
+> Updates will be handled through jDownloader2 directly, simply click the `Check for Updates` in the WebGUI.
 
+## Flavors
 
->**NOTE:** Please also check out the homepage from jDownloader: http://jdownloader.org/
+This repository provides multiple Docker images (flavors) built from different Dockerfiles and published to GitHub Container Registry as `ghcr.io/<OWNER>/docker-jdownloader2:<flavor>`:
 
-## Env params
-| Name | Value | Example |
-| --- | --- | --- |
-| CUSTOM_RES_W | Minimum of 1024 pixesl (leave blank for 1024 pixels) | 1024 |
-| CUSTOM_RES_H | Minimum of 768 pixesl (leave blank for 768 pixels) | 768 |
-| UMASK | Set permissions for newly created files | 000 |
-| UID | User Identifier | 99 |
-| GID | Group Identifier | 100 |
+- `latest` – Alias for `legacy` for backward compatibility.
+- `legacy` – Built from `Dockerfile`. Downloads jDownloader2, 7zip and Java from this repository.
+- `download_official` – Built from `Dockerfile.download_official`. Downloads JDownloader2, 7zip and Java from the official sources and enforces checksum validation by default.
+- `firefox` – Built from `Dockerfile.download_official` with `FLAVOR=firefox`. Same as `download_official`, but includes Firefox and an extended Fluxbox menu, so jDownloader's browser based captcha solving can be used.
+
+> [!CAUTION]
+> Changing flavours will overwrite/ remove some of your existing configuration files in the mounted volumes. Please back up your data before switching flavours! See [Changing flavors](#changing-flavors) for more information.
+
+## Environment Variables and Build Arguments
+
+### Basic params
+
+| Name | Description | Default | Flavor |
+| --- | --- | --- | --- |
+| CUSTOM_RES_W | Width in pixels for the VNC window; values below 1024 are clamped to 1024. | 1280 | all |
+| CUSTOM_RES_H | Height in pixels for the VNC window; values below 768 are clamped to 768. | 1024 | all |
+| UMASK | Permissions for newly created files and folders | 000 | all |
+| UID | User identifier used inside the container | 99 | all |
+| GID | Group identifier used inside the container | 100 | all |
+| SKIP_SHA_CHECKS | *(download_official / firefox only)* When `true` all checksum validation is skipped; when `false` (default) every JDownloader, sevenzip and JRE download must pass checksum validation or the build/startup aborts. | false | download_official, firefox |
+| JAVA_RUNTIME_VERSION | *(download_official / firefox only)* Exact Temurin runtime tag to install. Changing this value will trigger a re-download of the matching JRE if the existing runtime version does not match. | jdk-24.0.2+12 | download_official, firefox |
+
+### Advanced params
+
+#### Build-time args (used when building the image yourself)
+
+| Name | Description | Default | Flavor |
+| --- | --- | --- | --- |
+| JD_DOWNLOAD_URL | URL from which the image build downloads `JDownloader.jar`. | https://installer.jdownloader.org/JDownloader.jar | download_official, firefox |
+| JD_SHA_PAGE_URL | Support article URL that is scraped for the official JDownloader SHA256 checksum. | https://support.jdownloader.org/de/knowledgebase/article/install-jdownloader-on-nas-and-embedded-devices | download_official, firefox |
+| JD_SHA256 | Manual SHA256 override for `JDownloader.jar` when scraping the support article is undesired or fails. | empty (auto-scrape from support page) | download_official, firefox |
+| SEVENZIP_BEST_URL | SourceForge `best_release.json` endpoint to locate the latest sevenzipjbinding build. | https://sourceforge.net/projects/sevenzipjbind/best_release.json | download_official, firefox |
+| SEVENZIP_FALLBACK_URL | Static SourceForge URL used when the best-release lookup fails. | https://sourceforge.net/projects/sevenzipjbind/files/7-Zip-JBinding/16.02-2.01/sevenzipjbinding-16.02-2.01-Linux-amd64.zip/download?use_mirror=master | download_official, firefox |
+| SEVENZIP_MD5 | Manual MD5 override for the sevenzipjbinding archive. | empty (taken from best_release.json when available) | download_official, firefox |
+| FIREFOX_EXT_URL | URL of the Firefox extension XPI used for the browser captcha solver integration. | https://extensions.jdownloader.org/firefox.xpi | firefox |
+
+#### Runtime env vars (mainly for the `download_official` / `firefox` flavors)
+
+| Name | Description | Default | Flavor |
+| --- | --- | --- | --- |
+| CUSTOM_DEPTH | Color depth (bits per pixel) for the VNC session. Normally left at 16. | 16 | all |
+| CONNECTED_CONTAINERS | Optional `host:port` of a VPN or proxy container to watch; if set, this container will restart itself when the connection is lost. | empty string | all |
+| JDK_URL | Direct override for the Temurin archive URL (skips GitHub tag lookup). | unset | download_official, firefox |
+| JDK_SHA256 | Manual SHA256 override for the JRE archive when checksum checks are enabled. | unset | download_official, firefox |
+| DOWNLOAD_DIR | Default download folder path that jDownloader2 will use on first start for the official-download flavors. Point this to a path that is bind-mounted into the container. | /mnt/user/data/jdownloader | download_official, firefox |
+| GITHUB_TOKEN | Personal access token to avoid GitHub API rate limiting when resolving Temurin releases. | empty string | download_official, firefox |
+
+> [!NOTE]
+> For the `legacy` flavor, the download directory in the container is hardcoded to `/mnt/jDownloader` and cannot be changed via env vars.
 
 ## Run example
-```
+
+```bash
 docker run --name jDownloader2 -d \
     -p 8080:8080 \
     --env 'CUSTOM_RES_W=1024' \
     --env 'CUSTOM_RES_H=768' \
     --env 'UMASK=000' \
-	--env 'UID=99' \
-	--env 'GID=100' \
-	--volume /mnt/user/appdata/jdownloader2:/jDownloader2 \
+    --env 'UID=99' \
+    --env 'GID=100' \
+    --env 'SKIP_SHA_CHECKS=false' \
+    --env 'JAVA_RUNTIME_VERSION=jdk-24.0.2+12' \
+    --env 'GITHUB_TOKEN=""' \
+    --volume /mnt/user/appdata/jdownloader2:/jDownloader2 \
     --volume /mnt/user/jDownloader2:/mnt/jDownloader \
-    --restart=unless-stopped\
-	ich777/jdownloader2
+    --restart=unless-stopped \
+    ghcr.io/<OWNER>/docker-jdownloader2:download_official
 ```
 
-### Webgui address: http://[SERVERIP]:[PORT]/vnc.html?autoconnect=true
+Replace `<OWNER>` with the GitHub user or organization that owns this repository. To run another flavor, replace `:download_official` with `:legacy`, `:latest` or `:firefox`.
 
+### Webgui address
 
-#### Reverse Proxy with nginx example:
+`http://[SERVERIP]:[PORT]/vnc.html?autoconnect=true`
 
-```
+#### Reverse Proxy with nginx example
+
+```plaintext
 server {
-	listen 443 ssl;
+ listen 443 ssl;
 
-	include /config/nginx/ssl.conf;
-	include /config/nginx/error.conf;
+ include /config/nginx/ssl.conf;
+ include /config/nginx/error.conf;
 
-	server_name jdownloader2.example.com;
+ server_name jdownloader2.example.com;
 
-	location /websockify {
-		auth_basic           example.com;
-		auth_basic_user_file /config/nginx/.htpasswd;
-		proxy_http_version 1.1;
-		proxy_pass http://192.168.1.1:8080/;
-		proxy_set_header Upgrade $http_upgrade;
-		proxy_set_header Connection "upgrade";
+ location /websockify {
+  auth_basic           example.com;
+  auth_basic_user_file /config/nginx/.htpasswd;
+  proxy_http_version 1.1;
+  proxy_pass http://192.168.1.1:8080/;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "upgrade";
 
-		# VNC connection timeout
-		proxy_read_timeout 61s;
+  # VNC connection timeout
+  proxy_read_timeout 61s;
 
-		# Disable cache
-		proxy_buffering off;
-	}
-		location / {
-		rewrite ^/$ https://jdownloader2.example.com/vnc.html?autoconnect=true redirect;
-		auth_basic           example.com;
-		auth_basic_user_file /config/nginx/.htpasswd;
-		proxy_redirect     off;
-		proxy_set_header Range $http_range;
-		proxy_set_header If-Range $http_if_range;
-		proxy_set_header X-Real-IP $remote_addr;
-		proxy_set_header Host $host;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  # Disable cache
+  proxy_buffering off;
+ }
+  location / {
+  rewrite ^/$ https://jdownloader2.example.com/vnc.html?autoconnect=true redirect;
+  auth_basic           example.com;
+  auth_basic_user_file /config/nginx/.htpasswd;
+  proxy_redirect     off;
+  proxy_set_header Range $http_range;
+  proxy_set_header If-Range $http_if_range;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header Host $host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-		proxy_http_version 1.1;
-		proxy_set_header Upgrade $http_upgrade;
-		proxy_set_header Connection "upgrade";
-		proxy_pass http://192.168.1.1:8080/;
-	}
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "upgrade";
+  proxy_pass http://192.168.1.1:8080/;
+ }
 }
 ```
 
-## Set noVNC Password:
+## Set noVNC Password
+
  Please be sure to create the password first inside the container, to do that open up a console from the container (Unraid: In the Docker tab click on the container icon and on 'Console' then type in the following):
 
-1) **su $USER**
-2) **vncpasswd**
-3) **ENTER YOUR PASSWORD TWO TIMES AND PRESS ENTER AND SAY NO WHEN IT ASKS FOR VIEW ACCESS**
-
-Unraid: close the console, edit the template and create a variable with the `Key`: `TURBOVNC_PARAMS` and leave the `Value` empty, click `Add` and `Apply`.
-
-All other platforms running Docker: create a environment variable `TURBOVNC_PARAMS` that is empty or simply leave it empty:
+```bash
+su $USER
+vncpasswd
 ```
+
+Enter your password two times and press enter and say no when it asks for view access.
+
+### Unraid
+
+close the console, edit the template and create a variable with the `Key`: `TURBOVNC_PARAMS` and leave the `Value` empty, click `Add` and `Apply`.
+
+### All other platforms running Docker
+
+Create a environment variable `TURBOVNC_PARAMS` that is empty or simply leave it empty:
+
+```dockerfile
     --env 'TURBOVNC_PARAMS='
 ```
 
 This Docker was mainly edited for better use with Unraid, if you don't use Unraid you should definitely try it!
 
-#### Support Thread: https://forums.unraid.net/topic/83786-support-ich777-application-dockers/
+## Changing flavors
+
+Flavours can be changed by changing the image tag in the docker run command, compose file or Unraid template.
+
+When switching flavors the container adjusts a few configuration files inside the data volume (`/jDownloader2`):
+
+- Fluxbox configuration under `/etc/.fluxbox` is flavor-specific; on **each start** a snapshot of the current state is backed up.
+- When starting the `legacy` flavor, any non-default runtime directories under `/jDownloader2/runtime` are moved to `/jDownloader2/backups/runtime/` to avoid conflicts with the legacy Java runtime.
+
+Backups are not restored automatically. They are written into the mounted data path so they can be restored manually if needed:
+
+- `/jDownloader2/backups/etc/.fluxbox/`
+- `/jDownloader2/backups/runtime/`
+
+> [!NOTE]
+> When bind-mounting `/etc/.fluxbox` from the host, the host directory controls Fluxbox for all flavors and the per-flavor defaults from the image (including the extended Firefox menu) will not be applied automatically.
+
+## Support Thread
+
+<https://forums.unraid.net/topic/83786-support-ich777-application-dockers/>

--- a/conf_firefox/apps
+++ b/conf_firefox/apps
@@ -1,0 +1,1 @@
+! No per-application rules; use Fluxbox defaults for all windows.

--- a/conf_firefox/init
+++ b/conf_firefox/init
@@ -1,0 +1,12 @@
+! If you're looking for settings to configure, they won't be saved here until
+! you change something in the fluxbox configuration menu.
+
+session.styleFile: /usr/share/fluxbox/styles/Squared_for_Debian
+session.menuFile: /etc/.fluxbox/menu
+session.configVersion:	13
+session.screen0.toolbar.visible: true
+session.screen0.toolbar.widthPercent: 100
+session.screen0.toolbar.autoHide: false
+session.screen0.toolbar.tools: iconbar, systemtray, clock
+session.screen0.workspaces: 1
+session.screen0.workspaceNames: Main

--- a/conf_firefox/keys
+++ b/conf_firefox/keys
@@ -1,0 +1,26 @@
+# Root menu on left-click on desktop (convenience)
+OnDesktop Mouse1 :RootMenu
+
+# Classic root menu on right-click on desktop
+OnDesktop Mouse3 :RootMenu
+
+# Basic Alt+Tab window switching
+Mod1 Tab :NextWindow
+Mod1 Shift Tab :PrevWindow
+
+# Close and maximize via keyboard
+Mod1 F4 :Close
+Mod1 F10 :Maximize
+
+# Move window by dragging titlebar or Alt-drag anywhere
+OnTitlebar Move1 :StartMoving
+OnWindow Mod1 Mouse1 :StartMoving
+
+# Resize using window grips and borders
+OnLeftGrip Move1 :StartResizing bottomleft
+OnRightGrip Move1 :StartResizing bottomright
+OnWindowBorder Move1 :StartMoving
+
+# Titlebar actions: right-click menu and double-click maximize
+OnTitlebar Mouse3 :WindowMenu
+OnTitlebar Double Mouse1 :Maximize

--- a/conf_firefox/menu
+++ b/conf_firefox/menu
@@ -1,0 +1,14 @@
+[begin] (Menu)
+   [exec] (Terminal) {xterm -bg "#303030" -fg white}
+   [exec] (JDownloader2) {/jDownloader2/runtime/bin/java -jar /jDownloader2/JDownloader.jar}
+   [exec] (Firefox) {env HOME=/jDownloader2/firefox-home firefox-esr}
+   [submenu] (Fluxbox)
+      [config] (Configuration)
+      [submenu] (Styles)
+         [stylesdir] (/usr/share/fluxbox/styles)
+      [end]
+      [reconfig] (Reload Config)
+      [restart] (Restart Fluxbox)
+      [exit] (Exit Fluxbox)
+   [end]
+[end]

--- a/config/org.jdownloader.captcha.v2.solver.browser.BrowserCaptchaSolverConfig.browsercommandline.json
+++ b/config/org.jdownloader.captcha.v2.solver.browser.BrowserCaptchaSolverConfig.browsercommandline.json
@@ -1,0 +1,1 @@
+["env","HOME=/jDownloader2/firefox-home","firefox-esr","%s"]

--- a/config/org.jdownloader.settings.GeneralSettings.browsercommandline.json
+++ b/config/org.jdownloader.settings.GeneralSettings.browsercommandline.json
@@ -1,0 +1,1 @@
+["env","HOME=/jDownloader2/firefox-home","firefox-esr","%s"]

--- a/scripts/fetch-temurin.sh
+++ b/scripts/fetch-temurin.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Helper: download/verify/extract a specific Temurin Linux x64 HotSpot runtime
+# Uses env vars: JAVA_RUNTIME_VERSION, SKIP_SHA_CHECKS, JDK_URL (optional override), JDK_SHA256 (optional checksum), GITHUB_TOKEN
+
+DATA_DIR="${DATA_DIR:?DATA_DIR env var must be set}"
+UID="${UID:?UID env var must be set}"
+GID="${GID:?GID env var must be set}"
+JAVA_RUNTIME_VERSION="${JAVA_RUNTIME_VERSION:?JAVA_RUNTIME_VERSION env var must be set}"
+SKIP_SHA_CHECKS="${SKIP_SHA_CHECKS:-false}"
+
+echo "---fetch-temurin: starting---"
+
+runtime_dir="${DATA_DIR}/runtime"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+bin_tar="${tmp_dir}/jdk.tar.gz"
+sha_tmp="${tmp_dir}/jdk.sha256.txt"
+sha_file="${tmp_dir}/jdk.sha256"
+skip_flag="$(printf '%s' "${SKIP_SHA_CHECKS}" | tr '[:upper:]' '[:lower:]')"
+
+BIN_URL=""
+SHA_URL=""
+
+if [ -n "${JDK_URL:-}" ]; then
+  echo "JDK_URL provided, using ${JDK_URL}"
+  BIN_URL="${JDK_URL}"
+else
+  version_tag="${JAVA_RUNTIME_VERSION}"
+  version_no_prefix="${version_tag#jdk-}"
+  version_no_prefix="${version_no_prefix#jre-}"
+  major="${version_no_prefix%%[^0-9]*}"
+  if [ -z "${major}" ]; then
+    echo "Unable to derive Temurin major from JAVA_RUNTIME_VERSION=${JAVA_RUNTIME_VERSION}" >&2
+    exit 1
+  fi
+  api_url="https://api.github.com/repos/adoptium/temurin${major}-binaries/releases/tags/${version_tag}"
+  echo "Querying GitHub API: ${api_url}"
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    auth_header="Authorization: token ${GITHUB_TOKEN}"
+  else
+    auth_header=""
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to parse GitHub API responses" >&2
+    exit 1
+  fi
+  json="$(curl -sSL -H "$auth_header" "$api_url")"
+  bin_pattern="^OpenJDK${major}U-jdk_x64_linux_hotspot_.*\\.tar\\.gz$"
+  sha_pattern="^OpenJDK${major}U-jdk_x64_linux_hotspot_.*\\.tar\\.gz\\.sha256\\.txt$"
+  BIN_URL="$(echo "$json" | jq -r --arg pat "$bin_pattern" '.assets[] | select(.name | test($pat)) | .browser_download_url' | head -n1 || true)"
+  SHA_URL="$(echo "$json" | jq -r --arg pat "$sha_pattern" '.assets[] | select(.name | test($pat)) | .browser_download_url' | head -n1 || true)"
+fi
+
+if [ -z "$BIN_URL" ] || [ "$BIN_URL" = "null" ]; then
+  echo "Could not resolve Temurin binary URL. Provide JAVA_RUNTIME_VERSION or JDK_URL explicitly." >&2
+  exit 1
+fi
+
+echo "Resolved BIN_URL=${BIN_URL}"
+[ -n "$SHA_URL" ] && echo "Resolved SHA_URL=${SHA_URL}" || echo "No SHA asset found via API"
+
+echo "Downloading runtime archive..."
+if command -v curl >/dev/null 2>&1; then
+  curl -fL --retry 3 -o "$bin_tar" "$BIN_URL"
+else
+  wget -O "$bin_tar" "$BIN_URL"
+fi
+
+if [ "$skip_flag" != "true" ]; then
+  sha_value=""
+  if [ -n "${JDK_SHA256:-}" ]; then
+    sha_value="${JDK_SHA256}"
+  elif [ -n "$SHA_URL" ] && [ "$SHA_URL" != "null" ]; then
+    echo "Downloading sha file..."
+    if command -v curl >/dev/null 2>&1; then
+      curl -fL --retry 3 -o "$sha_tmp" "$SHA_URL"
+    else
+      wget -O "$sha_tmp" "$SHA_URL"
+    fi
+    sha_value="$(grep -Eo '^[0-9a-f]{64}' "$sha_tmp" | head -n1 || true)"
+  fi
+  if [ -z "$sha_value" ]; then
+    echo "Checksum enforcement enabled but no SHA data available" >&2
+    exit 1
+  fi
+  if ! command -v sha256sum >/dev/null 2>&1; then
+    echo "sha256sum binary missing while checksum enforcement is required" >&2
+    exit 1
+  fi
+  printf '%s  %s\n' "$sha_value" "$bin_tar" > "$sha_file"
+  sha256sum -c "$sha_file"
+else
+  echo "SKIP_SHA_CHECKS=true -> not verifying JRE download"
+fi
+
+echo "Extracting runtime into ${runtime_dir}"
+rm -rf "$runtime_dir"
+mkdir -p "$runtime_dir"
+tar -xzf "$bin_tar" -C "$runtime_dir"
+chown -R "${UID}:${GID}" "$runtime_dir" || true
+
+echo "---fetch-temurin: finished---"

--- a/scripts/start-server-download_official.sh
+++ b/scripts/start-server-download_official.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+export DISPLAY=:99
+export XAUTHORITY=${DATA_DIR}/.Xauthority
+
+resolve_runtime_paths() {
+    runtime_root=""
+    runtime_java=""
+    release_file=""
+    if [ ! -d "${DATA_DIR}/runtime" ]; then
+        return 1
+    fi
+    for d in "${DATA_DIR}/runtime"/*; do
+        [ -d "${d}" ] || continue
+        if [ ! -x "${d}/bin/java" ]; then
+            continue
+        fi
+        runtime_root="${d}"
+        runtime_java="${d}/bin/java"
+        release_file="${d}/release"
+        return 0
+    done
+    return 1
+}
+
+echo "---Checking for 'runtime' folder---"
+if [ ! -d ${DATA_DIR}/runtime ]; then
+	echo "---'runtime' folder not found, creating...---"
+	mkdir ${DATA_DIR}/runtime
+else
+	echo "---'runtime' folder found---"
+fi
+
+requested_runtime="${JAVA_RUNTIME_VERSION:?JAVA_RUNTIME_VERSION env var must be set}"
+requested_release="${requested_runtime#jdk-}"
+requested_release="${requested_release#jre-}"
+resolve_runtime_paths
+install_runtime="false"
+
+echo "---Ensuring runtime ${requested_runtime} is installed---"
+if [ -z "${runtime_java}" ] || [ ! -x "${runtime_java}" ]; then
+    echo "---Runtime binary missing---"
+    install_runtime="true"
+elif [ -z "${release_file}" ] || [ ! -f "${release_file}" ]; then
+    echo "---Runtime release file missing---"
+    install_runtime="true"
+else
+	installed_runtime="$(grep -E '^JAVA_RUNTIME_VERSION=' "${release_file}" | head -n1 | sed -nE 's/.*="([^"]+)".*/\1/p' || true)"
+	if [ -z "${installed_runtime}" ]; then
+		echo "---Unable to read JAVA_RUNTIME_VERSION from release file---"
+		install_runtime="true"
+	elif [ "${installed_runtime}" != "${requested_release}" ]; then
+		echo "---Installed runtime (${installed_runtime}) differs from requested ${requested_release}---"
+		install_runtime="true"
+	else
+		echo "---Runtime ${installed_runtime} already installed---"
+	fi
+fi
+
+if [ "${install_runtime}" = "true" ]; then
+	echo "---Downloading runtime (${requested_runtime}) via fetch-temurin.sh---"
+	/opt/scripts/fetch-temurin.sh || {
+		echo "---Failed to fetch Temurin runtime---"; sleep infinity; }
+	resolve_runtime_paths
+fi
+
+if [ -z "${runtime_java}" ] || [ ! -x "${runtime_java}" ]; then
+	echo "---------------------------------------------------------------------------------------------"
+	echo "---Runtime binary missing after installation attempt, putting server in sleep mode!---"
+	echo "---------------------------------------------------------------------------------------------"
+	sleep infinity
+fi
+
+echo "---Checking for 'jDownloader.jar'---"
+if [ ! -f ${DATA_DIR}/JDownloader.jar ]; then
+	echo "---'jDownloader.jar' not found, copying...---"
+	cd ${DATA_DIR}
+	cp /tmp/JDownloader.jar ${DATA_DIR}/JDownloader.jar
+	if [ ! -f ${DATA_DIR}/JDownloader.jar ]; then
+		echo "--------------------------------------------------------------------------------------"
+		echo "---Something went wrong can't copy 'jDownloader.jar', putting server in sleep mode!---"
+		echo "--------------------------------------------------------------------------------------"
+		sleep infinity
+	fi
+else
+	echo "---'jDownloader.jar' folder found---"
+fi
+
+echo "---Preparing Server---"
+
+echo "---Checking libraries---"
+if [ ! -d ${DATA_DIR}/libs ]; then
+	mkdir ${DATA_DIR}/libs
+fi
+missing_libs=true
+if [ -f ${DATA_DIR}/libs/sevenzipjbinding1509Linux.jar ] || \
+	[ -f ${DATA_DIR}/libs/sevenzipjbinding1509.jar ] || \
+	[ -f ${DATA_DIR}/libs/sevenzipjbinding-Linux-amd64.jar ] || \
+	[ -f ${DATA_DIR}/libs/sevenzipjbinding.jar ] || \
+	[ -f ${DATA_DIR}/libs/sevenzipjbinding-AllLinux.jar ]; then
+	missing_libs=false
+fi
+
+if [ "${missing_libs}" = "true" ]; then
+	echo "---Sevenzip libraries not found; checking /tmp/lib for jar files---"
+	if [ -d /tmp/lib ]; then
+		found_jar=false
+		for jar_file in /tmp/lib/*.jar; do
+			if [ ! -e "${jar_file}" ]; then
+				break
+			fi
+			found_jar=true
+			echo "---Copying sevenzip library: ${jar_file} -> ${DATA_DIR}/libs/---"
+			cp "${jar_file}" "${DATA_DIR}/libs/" || echo "---Warning: failed to copy ${jar_file}---"
+		done
+		if [ "${found_jar}" = "false" ]; then
+			echo "---Warning: /tmp/lib exists but contains no .jar files; continuing without sevenzip libraries---"
+		fi
+	else
+		echo "---Warning: /tmp/lib not found; continuing without sevenzip libraries---"
+	fi
+else
+	echo "---Sevenzip libraries already present in ${DATA_DIR}/libs---"
+fi
+
+echo "---Checking for old logfiles---"
+find $DATA_DIR -name "XvfbLog.*" -exec rm -f {} \;
+find $DATA_DIR -name "x11vncLog.*" -exec rm -f {} \;
+echo "---Checking for old display lock files---"
+rm -rf /tmp/.X99*
+rm -rf /tmp/.X11*
+rm -rf ${DATA_DIR}/.vnc/*.log ${DATA_DIR}/.vnc/*.pid
+chmod -R ${DATA_PERM} ${DATA_DIR}
+if [ -f ${DATA_DIR}/.vnc/passwd ]; then
+	chmod 600 ${DATA_DIR}/.vnc/passwd
+fi
+
+echo "---Setting up JDownloader config---"
+if [ ! -d ${DATA_DIR}/cfg ]; then
+	mkdir ${DATA_DIR}/cfg
+fi
+
+defaults=/opt/jdownloader-defaults
+if [ -d "$defaults" ]; then
+  for f in "$defaults"/*; do
+    [ -f "$f" ] || continue
+    base="$(basename "$f")"
+    [ -e "${DATA_DIR}/cfg/$base" ] || cp -a "$f" "${DATA_DIR}/cfg/$base"
+  done
+fi
+
+if [ ! -f "${DATA_DIR}/cfg/org.jdownloader.settings.GeneralSettings.json" ]; then
+    : "${DOWNLOAD_DIR}"
+    cat > "${DATA_DIR}/cfg/org.jdownloader.settings.GeneralSettings.json" <<EOF
+{
+  "defaultdownloadfolder" : "${DOWNLOAD_DIR}"
+}
+EOF
+fi
+
+echo "---Resolution check---"
+if [ -z "${CUSTOM_RES_W}" ]; then
+	CUSTOM_RES_W=1024
+fi
+if [ -z "${CUSTOM_RES_H}" ]; then
+	CUSTOM_RES_H=768
+fi
+
+if [ "${CUSTOM_RES_W}" -le 1024 ]; then
+	echo "---Width to low must be a minimal of 1024 pixels, correcting to 1024...---"
+    CUSTOM_RES_W=1024
+fi
+if [ "${CUSTOM_RES_H}" -le 768 ]; then
+	echo "---Height to low must be a minimal of 768 pixels, correcting to 768...---"
+    CUSTOM_RES_H=768
+fi
+
+sed -i '/"width"/c\  "width" : '${CUSTOM_RES_W}',' "${DATA_DIR}/cfg/org.jdownloader.settings.GraphicalUserInterfaceSettings.lastframestatus.json"
+sed -i '/"height"/c\  "height" : '${CUSTOM_RES_H}',' "${DATA_DIR}/cfg/org.jdownloader.settings.GraphicalUserInterfaceSettings.lastframestatus.json"
+echo "---Window resolution: ${CUSTOM_RES_W}x${CUSTOM_RES_H}---"
+
+echo "---Starting TurboVNC server---"
+vncserver -geometry ${CUSTOM_RES_W}x${CUSTOM_RES_H} -depth ${CUSTOM_DEPTH} :99 -rfbport ${RFB_PORT} -noxstartup -noserverkeymap ${TURBOVNC_PARAMS} 2>/dev/null
+sleep 2
+echo "---Starting Fluxbox---"
+screen -d -m env HOME=/etc /usr/bin/fluxbox
+sleep 2
+echo "---Starting noVNC server---"
+websockify -D --web=/usr/share/novnc/ --cert=/etc/ssl/novnc.pem ${NOVNC_PORT} localhost:${RFB_PORT}
+sleep 2
+
+echo "---Starting jDownloader2---"
+cd ${DATA_DIR}
+eval ${runtime_java} ${EXTRA_JVM_PARAMS} -jar ${DATA_DIR}/JDownloader.jar

--- a/scripts/start-server-legacy.sh
+++ b/scripts/start-server-legacy.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+export DISPLAY=:99
+export XAUTHORITY=${DATA_DIR}/.Xauthority
+
+echo "---Checking for 'runtime' folder---"
+if [ ! -d ${DATA_DIR}/runtime ]; then
+	echo "---'runtime' folder not found, creating...---"
+	mkdir ${DATA_DIR}/runtime
+else
+	echo "---'runtime' folder found---"
+fi
+
+echo "---Checking if Runtime is installed---"
+if [ -z "$(find ${DATA_DIR}/runtime -name jre*)" ]; then
+    if [ "${RUNTIME_NAME}" == "basicjre" ]; then
+    	echo "---Downloading and installing Runtime---"
+		cd ${DATA_DIR}/runtime
+		if wget -q -nc --show-progress --progress=bar:force:noscroll https://github.com/ich777/runtimes/raw/master/jre/basicjre.tar.gz ; then
+			echo "---Successfully downloaded Runtime!---"
+		else
+			echo "---Something went wrong, can't download Runtime, putting server in sleep mode---"
+			sleep infinity
+		fi
+        tar --directory ${DATA_DIR}/runtime -xvzf ${DATA_DIR}/runtime/basicjre.tar.gz
+        rm -R ${DATA_DIR}/runtime/basicjre.tar.gz
+    else
+    	if [ ! -d ${DATA_DIR}/runtime/${RUNTIME_NAME} ]; then
+        		echo "---------------------------------------------------------------------------------------------"
+        		echo "---Runtime not found in folder 'runtime' please check again! Putting server in sleep mode!---"
+        		echo "---------------------------------------------------------------------------------------------"
+        		sleep infinity
+        fi
+    fi
+else
+	echo "---Runtime found---"
+fi
+
+echo "---Checking for 'jDownloader.jar'---"
+if [ ! -f ${DATA_DIR}/JDownloader.jar ]; then
+	echo "---'jDownloader.jar' not found, copying...---"
+	cd ${DATA_DIR}
+	cp /tmp/JDownloader.jar ${DATA_DIR}/JDownloader.jar
+	if [ ! -f ${DATA_DIR}/JDownloader.jar ]; then
+		echo "--------------------------------------------------------------------------------------"
+		echo "---Something went wrong can't copy 'jDownloader.jar', putting server in sleep mode!---"
+		echo "--------------------------------------------------------------------------------------"
+		sleep infinity
+	fi
+else
+	echo "---'jDownloader.jar' folder found---"
+fi
+
+echo "---Preparing Server---"
+export RUNTIME_NAME="$(ls -d ${DATA_DIR}/runtime/* | cut -d '/' -f4)"
+
+echo "---Checking libraries---"
+if [ ! -d ${DATA_DIR}/libs ]; then
+	mkdir ${DATA_DIR}/libs
+fi
+if [ ! -f ${DATA_DIR}/libs/sevenzipjbinding1509Linux.jar ]; then
+	cd ${DATA_DIR}/libs
+	if [ ! -f ${DATA_DIR}/libs/lib.tar.gz ]; then
+		cp /tmp/lib.tar.gz ${DATA_DIR}/libs/lib.tar.gz
+	fi
+    if [ -f ${DATA_DIR}/libs/lib.tar.gz ]; then
+    	tar -xf ${DATA_DIR}/libs/lib.tar.gz
+    	rm ${DATA_DIR}/libs/lib.tar.gz
+	fi
+else
+	echo "---Libraries found!---"
+fi
+if [ ! -f ${DATA_DIR}/libs/sevenzipjbinding1509.jar ]; then
+	cd ${DATA_DIR}/libs
+	if [ ! -f ${DATA_DIR}/libs/lib.tar.gz ]; then
+		cp /tmp/lib.tar.gz ${DATA_DIR}/libs/lib.tar.gz
+	fi
+    if [ -f ${DATA_DIR}/libs/lib.tar.gz ]; then
+    	tar -xf ${DATA_DIR}/libs/lib.tar.gz
+    	rm ${DATA_DIR}/libs/lib.tar.gz
+	fi
+fi
+
+echo "---Checking for old logfiles---"
+find $DATA_DIR -name "XvfbLog.*" -exec rm -f {} \;
+find $DATA_DIR -name "x11vncLog.*" -exec rm -f {} \;
+echo "---Checking for old display lock files---"
+rm -rf /tmp/.X99*
+rm -rf /tmp/.X11*
+rm -rf ${DATA_DIR}/.vnc/*.log ${DATA_DIR}/.vnc/*.pid
+chmod -R ${DATA_PERM} ${DATA_DIR}
+if [ -f ${DATA_DIR}/.vnc/passwd ]; then
+	chmod 600 ${DATA_DIR}/.vnc/passwd
+fi
+
+echo "---Resolution check---"
+if [ -z "${CUSTOM_RES_W} ]; then
+	CUSTOM_RES_W=1024
+fi
+if [ -z "${CUSTOM_RES_H} ]; then
+	CUSTOM_RES_H=768
+fi
+
+if [ "${CUSTOM_RES_W}" -le 1024 ]; then
+	echo "---Width to low must be a minimal of 1024 pixels, correcting to 1024...---"
+    CUSTOM_RES_W=1024
+fi
+if [ "${CUSTOM_RES_H}" -le 768 ]; then
+	echo "---Height to low must be a minimal of 768 pixels, correcting to 768...---"
+    CUSTOM_RES_H=768
+fi
+
+if [ ! -d ${DATA_DIR}/cfg ]; then
+	mkdir ${DATA_DIR}/cfg
+fi
+
+if [ ! -f "${DATA_DIR}/cfg/org.jdownloader.settings.GraphicalUserInterfaceSettings.lastframestatus.json" ]; then
+    cd "${DATA_DIR}/cfg"
+    touch "org.jdownloader.settings.GraphicalUserInterfaceSettings.lastframestatus.json"
+	echo '{
+  "extendedState" : "NORMAL",
+  "width" : '${CUSTOM_RES_W}',
+  "height" : '${CUSTOM_RES_H}',
+  "x" : 0,
+  "visible" : true,
+  "y" : 0,
+  "silentShutdown" : false,
+  "screenID" : ":0.0",
+  "locationSet" : true,
+  "focus" : true,
+  "active" : true
+}' >> "${DATA_DIR}/cfg/org.jdownloader.settings.GraphicalUserInterfaceSettings.lastframestatus.json"
+fi
+
+sed -i '/"width"/c\  "width" : '${CUSTOM_RES_W}',' "${DATA_DIR}/cfg/org.jdownloader.settings.GraphicalUserInterfaceSettings.lastframestatus.json"
+sed -i '/"height"/c\  "height" : '${CUSTOM_RES_H}',' "${DATA_DIR}/cfg/org.jdownloader.settings.GraphicalUserInterfaceSettings.lastframestatus.json"
+if [ ! -f "${DATA_DIR}/cfg/org.jdownloader.settings.GeneralSettings.json" ]; then
+    cd "${DATA_DIR}/cfg"
+    touch "org.jdownloader.settings.GeneralSettings.json"
+	echo '{
+  "defaultdownloadfolder" : "/mnt/jDownloader"
+}' >> "${DATA_DIR}/cfg/org.jdownloader.settings.GeneralSettings.json"
+fi
+sed -i '/Downloads"/c\  "defaultdownloadfolder" : "\/mnt\/jDownloader",' "${DATA_DIR}/cfg/org.jdownloader.settings.GeneralSettings.json"
+echo "---Window resolution: ${CUSTOM_RES_W}x${CUSTOM_RES_H}---"
+
+echo "---Starting TurboVNC server---"
+vncserver -geometry ${CUSTOM_RES_W}x${CUSTOM_RES_H} -depth ${CUSTOM_DEPTH} :99 -rfbport ${RFB_PORT} -noxstartup -noserverkeymap ${TURBOVNC_PARAMS} 2>/dev/null
+sleep 2
+echo "---Starting Fluxbox---"
+screen -d -m env HOME=/etc /usr/bin/fluxbox
+sleep 2
+echo "---Starting noVNC server---"
+websockify -D --web=/usr/share/novnc/ --cert=/etc/ssl/novnc.pem ${NOVNC_PORT} localhost:${RFB_PORT}
+sleep 2
+
+echo "---Starting jDownloader2---"
+cd ${DATA_DIR}
+eval ${DATA_DIR}/runtime/${RUNTIME_NAME}/bin/java ${EXTRA_JVM_PARAMS} -jar ${DATA_DIR}/JDownloader.jar


### PR DESCRIPTION
First of all, thank you very much for your many contributions to the unRAID community!
I'm fairly new to unRAID and Docker in general. I noticed that the existing image uses bundled assets for JDownloader, 7zipjbinding and the JRE. Since I'm a bit paranoid, I figured I could use your JDownloader2 as a training project. This is the result of this endeavor:

### Summary of changes

This PR introduces a small set of new “flavors” (published as different image tags) so users can choose between the existing legacy behavior and a new “official sources” implementation.

#### Flavors / tags

- `legacy` (also tagged as `latest`): built from the existing Dockerfile and keeps the current behavior for backwards compatibility.
- `download_official`: built from a new Dockerfile that pulls JDownloader and sevenzipjbinding from official sources and verifies downloads by default.
- `firefox`: built from the same Dockerfile as `download_official`, but with Firefox + a Fluxbox menu setup to support browser-based captcha solving.

#### Review notes (to keep the diff approachable)

- The legacy path is intentionally preserved:
  - the legacy Dockerfile stays the entry point for the `legacy`/`latest` tags
  - the legacy runtime/start logic lives in `scripts/start-server-legacy.sh` and is kept as close as possible to upstream
- New logic is mostly isolated to:
  - `Dockerfile.download_official`
  - `scripts/start-server-download_official.sh` and `scripts/fetch-temurin.sh`
  - `scripts/start-server.sh` (a small dispatcher based on `IMAGE_FLAVOR`)

#### Split between build-time and runtime downloads

- For JDownloader + sevenzipjbinding I kept your philosopy: They are downloaded at image build time so every container start is fast and reproducible.
- The Java runtime is downloaded at container start (and cached under `/jDownloader2/runtime`) so it can be updated independently via `JAVA_RUNTIME_VERSION` without rebuilding the image (and because the downloader for this got out of hand).

#### CI / publishing

- Adds a GitHub Actions workflow that builds and publishes all 3 flavors to GHCR (`legacy`, `download_official`, `firefox`).
- `latest` remains an alias for `legacy`.
- The workflow is `linux/amd64` only because the upstream base image pulls an amd64-only TurboVNC package (and I have no idea how arm64 support would work).

#### Docs

- README updated with a flavor matrix and a separation between build-time args and runtime env vars.
- Documentation is formatted to satisfy markdownlint/remark-lint rules so VS Code will shut up.

#### Changing flavors (data volume impact)

Changing flavors is supported by changing the image tag in Docker/Unraid, but it will affect fluxbox config files and runtime files inside the mounted data volume (`/jDownloader2`). To make this safer:

- On each start, the container snapshots `/etc/.fluxbox` into `/jDownloader2/backups/etc/.fluxbox/`.
- When starting the `legacy` flavor, any non-legacy runtime directories under `/jDownloader2/runtime` are moved to `/jDownloader2/backups/runtime/` to avoid conflicts.

### Manual verification

I built and ran all three flavors locally and verified that the WebGUI is reachable and that the same `/jDownloader2` + download bind mounts can be reused across flavor switches.

### Follow-up

If you’re interested I can open a follow-up PR against the Unraid template repository to expose the new tags and relevant env vars.

Thanks again for your work on these images and all those driver plugins - they are fantastic! Even if you decide not to merge this PR, there are no hard feelings. I learned a lot building it.

Servus!